### PR TITLE
Update lxml version requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ anytree == 2.8.0
 colorama == 0.4.4
 cryptography == 3.4.4
 lark_parser == 0.12.0
-lxml == 4.6.3
+lxml == 4.6.4
 openpyxl == 3.0.9
 requests == 2.24.0
 requests_toolbelt == 0.9.1


### PR DESCRIPTION
This version does not have build issues when installing via pip in a Windows environment.