### PR TITLE
Allow [()] as first character of SPACYNAME, eg. '(X) Label'

### DIFF
--- a/elmclient/_queryparser.py
+++ b/elmclient/_queryparser.py
@@ -86,7 +86,7 @@ unsignedinteger     : /[1-9][0-9]*/
 
 URI_REF_ESC         : /<https?:.*?>/
 
-SPACYNAME           : /[ a-zA-Z0-9_][^']*/
+SPACYNAME           : /[ a-zA-Z0-9_()][^']*/
 
 urioffoldername     : "$" string_esc
 
@@ -533,7 +533,7 @@ identifier     : ( ( URI_REF_ESC | NAME | "'" SPACYNAME "'" ) ":" )? NAME
 
 URI_REF_ESC     : /<https?:.*>/
 NAME            : /[a-zA-Z0-9_][^, ]*/
-SPACYNAME           : /[a-zA-Z0-9_][^']*/
+SPACYNAME           : /[a-zA-Z0-9_()][^']*/
 """
 
 _orderby_grammar = """


### PR DESCRIPTION
In my company's Doors Next instance, there are shape properties with a `dcterms:title` that start with "(" and contain space. This is not allowed in the grammar defined for the [Lark](https://github.com/lark-parser/lark) query parser.

Shape propery example:

```xml
<oslc:Property>
  <oslc:valueType rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
  <oslc:propertyDefinition rdf:resource="https://nceelmprod01.stoneridge.com/rm/types/AD_1CbeoSHkEeyJlc_q460BxA"/>
  <oslc:occurs rdf:resource="http://open-services.net/ns/core#Zero-or-one"/>
  <dcterms:description rdf:parseType="Literal"></dcterms:description>
  <dcterms:title rdf:parseType="Literal">(SRE) Stakeholder Requirement ID</dcterms:title>
  <oslc:name>AD_1CbeoSHkEeyJlc_q460BxA</oslc:name>
</oslc:Property>
```

Failing query: _RMComponent.do_complex_query call with `select`=`'(SRE) Stakeholder Requirement ID'`
