### PR TITLE
fix: Avoid crash from calling termios.tcgetattr if stdin is no tty

### DIFF
--- a/elmclient/oslcqueryapi.py
+++ b/elmclient/oslcqueryapi.py
@@ -54,6 +54,9 @@ except ImportError:
             termios.tcsetattr(fd, termios.TCSADRAIN, old)
 
     def kbhit():
+        if not sys.stdin.isatty():
+            return False
+
         # Save the terminal settings
         fd = sys.stdin.fileno()
         new_term = termios.tcgetattr(fd)


### PR DESCRIPTION
Fixes https://github.com/IBM/ELM-Python-Client/issues/68

This PR makes the `kbhit` function return `False` if there is no tty attached to stdin. This is semantically correct, as there cannot be a keyboard hit if there is no tty. 

Another implementation idea was to introduce something like an `interactive` parameter which could be controlled from the outside, but I like this implementation more as it is super compact and easy to understand, while still keeping the intended functionality of the `kbhit` function.