### PR TITLE
fix: XML pretty-printing crash for non-ASCII in httpops

### DIFF
--- a/elmclient/httpops.py
+++ b/elmclient/httpops.py
@@ -594,9 +594,13 @@ class HttpRequest():
                     if rawtext.startswith( '<?xml' ) or rawtext.startswith( '<rdf' ):
                         # assume XML
 #                        print( f"is xml {rawtext[0:4]}" )
-                        tree = ET.fromstring( rawtext )
-                        ET.indent(tree, space="       " )
-                        rawtext = ET.tostring( tree )
+                        try:
+                            body_bytes = request.body if isinstance(request.body, bytes) else request.body.encode('utf-8')
+                            tree = ET.fromstring( body_bytes )
+                            ET.indent(tree, space="       " )
+                            rawtext = ET.tostring( tree, encoding='unicode' )
+                        except Exception:
+                            pass  # keep rawtext as-is
                     else:
 #                        print( f"not xml {rawtext[0:4]}" )
                         pass
@@ -658,9 +662,12 @@ class HttpRequest():
                     if rawtext.startswith( '<?xml' ) or rawtext.startswith( '<rdf' ):
                         # assume XML
 #                        print( f"is xml {rawtext[0:4]}" )
-                        tree = ET.fromstring( rawtext.encode() )
-                        ET.indent(tree, space="  " )
-                        rawtext = ET.tostring( tree ).decode()
+                        try:
+                            tree = ET.fromstring( response.content )
+                            ET.indent(tree, space="  " )
+                            rawtext = ET.tostring( tree, encoding='unicode' )
+                        except Exception:
+                            pass  # keep rawtext as-is
                     else:
 #                        print( f"not xml {rawtext[0:4]}" )
                         pass


### PR DESCRIPTION
This pull request solves #121 by improving the robustness of XML handling in the logging functions of `elmclient/httpops.py`. The changes ensure that XML parsing errors do not interrupt logging by introducing exception handling and proper encoding management.

Improvements to XML logging robustness:

* Added `try`/`except` blocks around XML parsing and formatting in both `_log_request` and `_log_response` to prevent failures when encountering malformed XML or encoding issues. [[1]](diffhunk://#diff-fe412018005f737d11a9752ee6a64599063740ec3a3c12ce2d6ab3b07a603e9dL597-R603) [[2]](diffhunk://#diff-fe412018005f737d11a9752ee6a64599063740ec3a3c12ce2d6ab3b07a603e9dL661-R670)
* Updated XML serialization to use `encoding='unicode'`, ensuring consistent output and handling of string/byte inputs. [[1]](diffhunk://#diff-fe412018005f737d11a9752ee6a64599063740ec3a3c12ce2d6ab3b07a603e9dL597-R603) [[2]](diffhunk://#diff-fe412018005f737d11a9752ee6a64599063740ec3a3c12ce2d6ab3b07a603e9dL661-R670)