### PR TITLE
ci: add GitHub Actions workflow for automated PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build tools
+        run: pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow for automated PyPI publishing when version tags are pushed.

Closes #126

## Changes

- **`.github/workflows/publish.yml`** — Workflow that:
  - Triggers on `v*` tags (e.g., `v0.37.0`)
  - Builds the package with `python -m build`
  - Publishes to PyPI using `twine`

## Setup Required

1. Create a PyPI API token at https://pypi.org/manage/account/token/
2. Add it as a repository secret named `PYPI_TOKEN`

## Usage

After merging, publishing is as simple as:

```bash
git tag v0.37.0
git push origin v0.37.0
```

The workflow will automatically build and publish to PyPI.

## Why

- Current PyPI version lags behind the GitHub master branch
- Users needing recent fixes must install from git, which is fragile for production
- Automated publishing ensures PyPI stays in sync with releases