### PR TITLE
Use modern lark parser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ CacheControl
 anytree
 colorama
 cryptography
-lark_parser
+lark
 lxml
 openpyxl
 python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     packages=["elmclient", "elmclient.examples","elmclient.tests"],
     include_package_data=True,
-    install_requires=['CacheControl','anytree',"colorama","cryptography",'lark_parser','lockfile','lxml',"openpyxl","python-dateutil", "pytz", "requests","requests_toolbelt",'tqdm','urllib3', "bump2version", "twine",'filelock'],
+    install_requires=['CacheControl','anytree',"colorama","cryptography",'lark','lockfile','lxml',"openpyxl","python-dateutil", "pytz", "requests","requests_toolbelt",'tqdm','urllib3', "bump2version", "twine",'filelock'],
     entry_points={
         "console_scripts": [
             "oslcquery=elmclient.examples.oslcquery:main",


### PR DESCRIPTION
The `lark_parser` package has been superseded by `lark`. As both use the
same namespace (`lark`), using `lark_parser` can result in a collusion,
if users of the ELM client use `lark` as well within their dependency
tree. Then the runtime behavior becomes installation-order dependent.

As the usages of `lark` within the library seem to work fine with the
modern `lark` as well, using the modern package should be preferred.